### PR TITLE
port code for exporting dm-key test vectors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+test/generate/vectors

--- a/feed-keys.js
+++ b/feed-keys.js
@@ -9,11 +9,11 @@ const na = require('sodium-native')
 module.exports = class FeedKeys {
   constructor (keys) {
     if (!isValid(keys.public)) {
-      throw new Error(`FeedKeys expects a 'public' key of form <base64>.ed25119 or <base64>.bbfeed-v1, got ${keys.public}`)
+      throw new Error(`FeedKeys expects a 'public' key of form <base64>.ed25119, got ${keys.public}`)
     }
     if (keys.private && !isValid(keys.private)) {
       // private key optional
-      throw new Error(`FeedKeys expects any 'private' key to be of form <base64>.ed25119 or <base64>.bbfeed-v1, got ${keys.private}`)
+      throw new Error(`FeedKeys expects any 'private' key to be of form <base64>.ed25119, got ${keys.private}`)
     }
 
     this.public = bufferize(keys.public)
@@ -43,10 +43,10 @@ module.exports = class FeedKeys {
 function isValid (t) {
   return (
     typeof t === 'string' &&
-      (t.endsWith('.ed25519') || t.endsWith('.bbfeed-v1'))
+    t.endsWith('.ed25519')
   )
 }
 
 function bufferize (str) {
-  return Buffer.from(str.replace('.ed25519', '').replace('.bbfeed-v1', ''), 'base64')
+  return Buffer.from(str.replace('.ed25519', ''), 'base64')
 }

--- a/feed-keys.js
+++ b/feed-keys.js
@@ -9,11 +9,11 @@ const na = require('sodium-native')
 module.exports = class FeedKeys {
   constructor (keys) {
     if (!isValid(keys.public)) {
-      throw new Error(`FeedKeys expects a 'public' key of form <base64>.ed25119, got ${keys.public}`)
+      throw new Error(`FeedKeys expects a 'public' key of form <base64>.ed25119 or <base64>.bbfeed-v1, got ${keys.public}`)
     }
     if (keys.private && !isValid(keys.private)) {
       // private key optional
-      throw new Error(`FeedKeys expects any 'private' key to be of form <base64>.ed25119, got ${keys.private}`)
+      throw new Error(`FeedKeys expects any 'private' key to be of form <base64>.ed25119 or <base64>.bbfeed-v1, got ${keys.private}`)
     }
 
     this.public = bufferize(keys.public)
@@ -33,9 +33,9 @@ module.exports = class FeedKeys {
 
   toBuffer () {
     return {
-      public: this.public,
       secret: this.secret,
-      private: this.secret
+      private: this.secret, // alias
+      public: this.public
     }
   }
 }

--- a/index.js
+++ b/index.js
@@ -3,6 +3,6 @@ module.exports = {
   directMessageKey: require('./direct-message-key'),
 
   // testing
-  DHKeys: require('./direct-message-key'),
+  DHKeys: require('./dh-keys'),
   FeedKeys: require('./feed-keys')
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "ssb-private-group-keys",
       "version": "0.1.0",
       "license": "AGPL-3.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,10 @@
     "type": "git",
     "url": "git://github.com/ssbc/ssb-private-group-keys.git"
   },
+  "scripts": {
+    "test": "tape test/*.js | tap-bail | tap-spec",
+    "generate": "rm test/generate/*/* && node test/generate/*.js"
+  },
   "dependencies": {
     "envelope-js": "^1.0.0",
     "futoin-hkdf": "^1.3.2",
@@ -21,9 +25,6 @@
     "tap-bail": "^1.0.0",
     "tap-spec": "^5.0.0",
     "tape": "^5.2.2"
-  },
-  "scripts": {
-    "test": "tape test/*.js | tap-bail | tap-spec"
   },
   "author": "mixmix",
   "license": "AGPL-3.0"

--- a/test/direct-message-key.test.js
+++ b/test/direct-message-key.test.js
@@ -37,10 +37,7 @@ test('direct-message-key', t => {
     'DirectMessageKey.easy produces same result'
   )
 
-  console.log('testing vectors')
   /* test vectors we've imported */
-
-  // WIP - export new test vectors, link + get this passing
   vectors.forEach(vector => {
     decodeLeaves(vector)
 

--- a/test/feed-keys.test.js
+++ b/test/feed-keys.test.js
@@ -14,7 +14,7 @@ test('FeedKeys', t => {
   )
 
   const bendyKeys = ssbKeys.generate()
-  bendyKeys.public = bendyKeys.id = bendyKeys.id.replace('ed25519', 'bbfeed-v1')
+  bendyKeys.id = bendyKeys.id.replace('ed25519', 'bbfeed-v1')
 
   const bendyPKBuff = Buffer.from(bendyKeys.public.replace('.ed25519', ''), 'base64')
   const bendySKBuff = Buffer.from(bendyKeys.private.replace('.ed25519', ''), 'base64')

--- a/test/generate/direct-message-key.js
+++ b/test/generate/direct-message-key.js
@@ -1,0 +1,30 @@
+const { DHFeedKeys, print } = require('../helpers')
+const directMessageKey = require('../../direct-message-key')
+
+const generators = [
+  (i) => {
+    const my = DHFeedKeys()
+    const your = DHFeedKeys()
+
+    const sharedKey = directMessageKey(my.dh.secret, my.dh.public, my.feedId, your.dh.public, your.feedId)
+
+    const vector = {
+      type: 'direct_message_shared_key',
+      description: 'calculate a shared DM key for another feedID. Note all inputs here are TFK encoded!',
+      input: {
+        my_dh_secret: my.dh.secret,
+        my_dh_public: my.dh.public,
+        my_feed_id: my.feedId,
+
+        your_dh_public: your.dh.public,
+        your_feed_id: your.feedId
+      },
+      output: {
+        shared_key: sharedKey
+      }
+    }
+    print(`vectors/direct-message-key${i + 1}.json`, vector)
+  }
+]
+
+generators.forEach((fn, i) => fn(i))

--- a/test/helpers/encode-leaves.js
+++ b/test/helpers/encode-leaves.js
@@ -1,0 +1,21 @@
+const { isBuffer } = Buffer
+const isRegex = (el) => el.constructor === RegExp
+
+module.exports = function encodeLeaves (vector) {
+  Object.entries(vector)
+    .forEach(([key, value]) => {
+      if (value === null) return
+
+      if (isBuffer(value)) {
+        vector[key] = value.toString('base64')
+      } else if (isRegex(value)) {
+        vector[key] = value.toString()
+          .replace(/^\//, '')
+          .replace(/\/$/, '')
+      } else if (typeof value === 'object') {
+        vector[key] = encodeLeaves(value)
+      }
+    })
+
+  return vector
+}

--- a/test/helpers/index.js
+++ b/test/helpers/index.js
@@ -1,7 +1,11 @@
-const decodeLeaves = require('./decode-leaves')
 const DHFeedKeys = require('./dh-feed-keys')
+const encodeLeaves = require('./encode-leaves')
+const decodeLeaves = require('./decode-leaves')
+const print = require('./print')
 
 module.exports = {
   DHFeedKeys,
-  decodeLeaves
+  encodeLeaves,
+  decodeLeaves,
+  print
 }

--- a/test/helpers/print.js
+++ b/test/helpers/print.js
@@ -1,0 +1,30 @@
+/* eslint-disable camelcase */
+
+const fs = require('fs')
+const { join, dirname } = require('path')
+const error_codes = require('envelope-spec/error_codes.json')
+const encodeLeaves = require('./encode-leaves')
+
+module.exports = function print (relativeFilePath, vector) {
+  if (vector.error_code) {
+    if (!(vector.error_code in error_codes)) {
+      throw new Error(`invalid error_code code: "${vector.error_code}", see envelope-spec/constants.json`)
+    }
+  }
+
+  const output = JSON.stringify(encodeLeaves(vector), null, 2)
+  const filePath = join(__dirname, '../generate', relativeFilePath)
+
+  fs.mkdir(dirname(filePath), { recursive: true }, (err) => {
+    if (err) throw err
+
+    fs.writeFile(filePath, output, (err) => {
+      if (err) throw err
+    })
+  })
+
+  console.log()
+  console.log('# private-groups-spec/' + relativeFilePath)
+  console.log(output)
+  console.log()
+}


### PR DESCRIPTION
This PR pulls over the code responsible for generating test-vectors for the `private-group-spec`.

I plan to put more into this repo, along with more test vector generating code, so this is necessary cruft.