### PR TITLE
Make sure easy dm also works for bendy butt

### DIFF
--- a/direct-message-key.js
+++ b/direct-message-key.js
@@ -47,8 +47,14 @@ function EasyDirectMessageKey (ssbKeys) {
   }
 
   return function EasyDirectMessageKey (feedId) {
+    const dotIndex = feedId.indexOf('.')
+    const keys = {
+      public: feedId.substring(1, dotIndex > 0 ? dotIndex : feedId.length)
+      // prunes the @ + suffix
+    }
+
     const your = {
-      dh: new DHKeys({ public: feedId.replace('@', '') }, { fromEd25519: true }).toBFE(),
+      dh: new DHKeys(keys, { fromEd25519: true }).toBFE(),
       feedId: bfe.encode(feedId)
     }
 

--- a/test/direct-message-key.test.js
+++ b/test/direct-message-key.test.js
@@ -1,7 +1,15 @@
 /* eslint-disable camelcase */
 
 const test = require('tape')
-const { generate } = require('ssb-keys')
+const ssbKeys = require('ssb-keys')
+const bbKeys = {
+  generate () {
+    const keys = ssbKeys.generate()
+    keys.id = keys.id.replace('ed25519', 'bbfeed-v1')
+    return keys
+  }
+}
+
 const vectors = [
   require('private-group-spec/vectors/direct-message-key1.json')
 ]
@@ -11,10 +19,10 @@ const directMessageKey = require('../direct-message-key')
 
 test('direct-message-key', t => {
   /* local tests */
-  const mySSBKeys = generate()
+  const mySSBKeys = ssbKeys.generate()
   const my = DHFeedKeys(mySSBKeys)
 
-  const yourSSBKeys = generate()
+  const yourSSBKeys = ssbKeys.generate()
   const your = DHFeedKeys(yourSSBKeys)
   // directMessageKey (my_dh_secret, my_dh_public, your_dh_public, my_feed_id, your_feed_id) {
 
@@ -34,7 +42,16 @@ test('direct-message-key', t => {
   t.deepEqual(
     directMessageKey.easy(mySSBKeys)(yourSSBKeys.id),
     directMessageKey(my.dh.secret, my.dh.public, my.feedId, your.dh.public, your.feedId),
-    'DirectMessageKey.easy produces same result'
+    'DirectMessageKey.easy produces same result (classic)'
+  )
+
+  const bendyKeys = bbKeys.generate()
+  const bendy = DHFeedKeys(bendyKeys)
+
+  t.deepEqual(
+    directMessageKey.easy(mySSBKeys)(bendyKeys.id),
+    directMessageKey(my.dh.secret, my.dh.public, my.feedId, bendy.dh.public, bendy.feedId),
+    'DirectMessageKey.easy produces same result (bendy butt)'
   )
 
   /* test vectors we've imported */


### PR DESCRIPTION
Noticed that there was a problem with the previous cleanup in that dm easy assumes we can just take the last part of the id and use that for public. This changes that part to be a bit more general and adds a test for what was failing before.