### PR TITLE
expose diffie-hellman-keys in the API

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,15 +6,6 @@ Currently supports classic & bendy butt feed types.
 
 ## API
 
-### `new SecretKey(length?) => secretKey`
-
-Create a secret key that can be used for the group or message key.
-
-methods:
-- `secretKey.toBuffer() => buffer` return raw buffer with the key data in it
-- `secretKey.toString() => string` returns a `base64` encoded string of the key
-
-
 ### `directMessageKey(x_dh_secret, x_dh_public, x_feed_id, y_dh_public, y_feed_id) => { key, scheme }`
 
 Create a shared key for communication between your feed and _another_ feed.
@@ -33,10 +24,11 @@ All inputs are [BFE] style buffers.
 The output is a `key` (buffer) and associated `scheme` (string) which can be passed into an envelope `key_slot`
 
 
-### `directMessageKey.easy(myKeys) => makeKey(feedId) => { key, scheme }`
+#### `directMessageKey.easy(myKeys) => makeKey(feedId) => { key, scheme }`
 
 Convenience function which wraps `directMessageKey`
 
+---
 
 ### `poBoxKey(x_dh_secret, x_dh_public, x_id, y_dh_public, y_id) => { key, scheme }`
 
@@ -53,11 +45,58 @@ All inputs are [BFE] style buffers.
 The output is a `key` (buffer) and associated `scheme` (string) which can be passed into an envelope `key_slot`
 
 
-### `poBoxKey.easy(myKeys) => makeKey(poboxId) => { key, scheme }`
+#### `poBoxKey.easy(myKeys) => makeKey(poboxId) => { key, scheme }`
 
 Convenience function which wraps `poBoxKey`
 
 Can also be used `poBoxKey.easy(poBoxKeys) => makeKey(authorFeedId) => { key, scheme }`
+
+---
+
+### `new SecretKey(length?) => secretKey`
+
+Create a secret key that can be used for the group or message key.
+
+methods:
+- `secretKey.toBuffer() => buffer` return raw buffer with the key data in it
+- `secretKey.toString() => string` returns a `base64` encoded string of the key
+
+---
+
+### `new DiffieHellmanKeys(keys?, opts?) => dhKeys`
+
+_alias: `DHKeys`_
+
+where:
+- `keys` *Object* (optional)
+    - is a pair of keys `{ public, secret? }`, each a Buffer or base64 encoded String
+        - `public` is required, `secret` is optional
+    - if not provided, you are expected to call `dhKeys.generate()` to generate a keypair
+- `opts` *Object* (optional)
+    - `opts.fromEd25519` *Boolean* sets whether the keys are ed25519 signing keys you would like converted to curve25519 encryption keys.
+        - default: `false`
+- `dhKeys` *DiffieHellmanKeys instance* with methods:
+    - `dhKeys.generate() => dhKeys` - generates public and private dh keys
+    - `dhKeys.toBuffer() => { public: Buffer, secret: Buffer }` - returns the raw keys as Buffers
+    - `dhKeys.toBFE() => { public: BFE, secret: BFE }` - return [BFE] encodings of the keys (as Buffers) 
+        - NOTE: the `format` chosen for BFE is _guessed_ based on how the keys were input
+            - if `opts.fromEd25519 = true` was used, it's assumed these are dm keys (`format = 0`)
+            - else it's asssumed these are P.O. Box keys (`format = 1`)
+
+### `DiffieHellmanKeys.scalarMult(A, B) => result`
+
+A class method for creating shared encryption keys.
+- `A` a DHKeys instance, must include `secret` key
+- `B` a DHKeys instance
+- `result` *Buffer* the result of the scalarMult
+    - only useful in advanced cases to conserve memory
+
+NOTE:
+- method also takes appropriately shaped objects, see source code.
+- there's an advanced signature if you need to conserve memory `(A, B, result) => result`
+
+
+---
 
 ## History
 

--- a/diffie-hellman-keys.js
+++ b/diffie-hellman-keys.js
@@ -1,7 +1,9 @@
 const na = require('sodium-native')
 
-// this is for converting FeedKeys (ed25119 signing keys) into
-// Diffie-Hellman keys (curve25519 based shared key encryption)
+// this is a helper for handling Diffie-Hellman keys (for curve25519 based shared key encryption)
+// it can also converting FeedKeys (ed25119 signing keys) into curve25519 keys
+//
+// NOTE - for BFE encryption, pay close attention to the "format".
 
 module.exports = class DHKeys {
   static scalarMult (a, b, result) {

--- a/index.js
+++ b/index.js
@@ -1,5 +1,10 @@
+const DiffieHellmanKeys = require('./diffie-hellman-keys')
+
 module.exports = {
   SecretKey: require('./secret-key'),
+  DiffieHellmanKeys,
+  DHKeys: DiffieHellmanKeys, // alias
+
   directMessageKey: require('./direct-message-key'),
   poBoxKey: require('./po-box-key')
 }

--- a/lib/easyify.js
+++ b/lib/easyify.js
@@ -1,7 +1,7 @@
 const { isFeed: isClassicFeed } = require('ssb-ref')
 const bfe = require('ssb-bfe')
 
-const DHKeys = require('./dh-keys')
+const DHKeys = require('../diffie-hellman-keys')
 const isPOBox = require('./is-po-box')
 
 module.exports = function easyify (keyFn) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,11 +1,9 @@
 const crypto = require('crypto')
 
-const DHKeys = require('./dh-keys')
 const easyify = require('./easyify')
 const isPOBox = require('./is-po-box')
 
 module.exports = {
-  DHKeys,
   SHA256 (input) {
     const hash = crypto.createHash('sha256')
 

--- a/secret-key.js
+++ b/secret-key.js
@@ -4,7 +4,7 @@ const na = require('sodium-native')
 // - a group's symmetric key (`group_key`)
 // - an envelopes top level key (`msg_key`) from which others are derived
 
-class SecretKey {
+module.exports = class SecretKey {
   constructor (length) {
     this.key = na.sodium_malloc(length || na.crypto_secretbox_KEYBYTES)
     na.randombytes_buf(this.key)
@@ -18,5 +18,3 @@ class SecretKey {
     return this.key
   }
 }
-
-module.exports = SecretKey

--- a/test/diffie-hellman-keys.test.js
+++ b/test/diffie-hellman-keys.test.js
@@ -4,9 +4,9 @@ const test = require('tape')
 const na = require('sodium-native')
 const ssbKeys = require('ssb-keys')
 
-const { DHKeys: Keys } = require('../../lib')
+const { DHKeys: Keys } = require('..')
 
-test('dh-keys', t => {
+test('diffie-hellman-keys', t => {
   /* new DHKeys().generate() */
   const a = new Keys().generate()
   const b = new Keys().generate()

--- a/test/helpers/dh-feed-keys.js
+++ b/test/helpers/dh-feed-keys.js
@@ -1,7 +1,6 @@
 const { generate } = require('ssb-keys')
-
 const bfe = require('ssb-bfe')
-const { DHKeys } = require('../../lib')
+const DHKeys = require('../../diffie-hellman-keys')
 
 module.exports = function DHFeedKeys (keys) {
   const ssbKeys = keys || generate()

--- a/test/helpers/dh-po-box-keys.js
+++ b/test/helpers/dh-po-box-keys.js
@@ -1,5 +1,5 @@
 const bfe = require('ssb-bfe')
-const { DHKeys } = require('../../lib')
+const DHKeys = require('../../diffie-hellman-keys')
 
 module.exports = function DHPOBoxKeys (keys) {
   keys = keys || new DHKeys().generate()


### PR DESCRIPTION
I found myself wanting to use these methods in `ssb-tribes` and did not want to just reach in and grab them in case the file location changed.

So I've made DiffieHellmanKeys part of the exported API, and added documentation for them. I think they will be helpful elsewhere in the ecosystem too