### PR TITLE
allow constructing SecretKey from buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,13 @@ methods:
 - `secretKey.toBuffer() => buffer` return raw buffer with the key data in it
 - `secretKey.toString() => string` returns a `base64` encoded string of the key
 
+### `new SecretKey(buffer) => secretKey`
+
+An alternative way to use the constructor, in case you already have the group
+key bytes as a buffer, is to pass the buffer as the argument. This simply
+"embodies" the group key as a `SecretKey` instance, it doesn't generate anything
+new.
+
 ---
 
 ### `new DiffieHellmanKeys(keys?, opts?) => dhKeys`
@@ -80,7 +87,7 @@ where:
 - `dhKeys` *DiffieHellmanKeys instance* with methods:
     - `dhKeys.generate() => dhKeys` - generates public and private dh keys
     - `dhKeys.toBuffer() => { public: Buffer, secret: Buffer }` - returns the raw keys as Buffers
-    - `dhKeys.toBFE() => { public: BFE, secret: BFE }` - return [BFE] encodings of the keys (as Buffers) 
+    - `dhKeys.toBFE() => { public: BFE, secret: BFE }` - return [BFE] encodings of the keys (as Buffers)
 
 ### `DiffieHellmanKeys.scalarMult(A, B) => result`
 

--- a/secret-key.js
+++ b/secret-key.js
@@ -5,9 +5,13 @@ const na = require('sodium-universal')
 // - an envelopes top level key (`msg_key`) from which others are derived
 
 module.exports = class SecretKey {
-  constructor (length) {
-    this.key = na.sodium_malloc(length || na.crypto_secretbox_KEYBYTES)
-    na.randombytes_buf(this.key)
+  constructor (lengthOrBuffer) {
+    if (Buffer.isBuffer(lengthOrBuffer)) {
+      this.key = lengthOrBuffer
+    } else {
+      this.key = na.sodium_malloc(length || na.crypto_secretbox_KEYBYTES);
+      na.randombytes_buf(this.key)
+    }
   }
 
   toString (encoding = 'base64') {


### PR DESCRIPTION
Context: I need to fetch the group subfeed, but the group subfeed has the secret key bytes as the `feedpurpose`. What I have is the groupId, and from that I can fetch (from keyring) the secret key bytes, but then I need to create a `SecretKey` class instance.

Asking for a review from whoever sees this first.